### PR TITLE
[ECWoC26] Fix CORS error blocking OTP requests

### DIFF
--- a/Backend/index.js
+++ b/Backend/index.js
@@ -27,11 +27,15 @@ import { Server } from 'socket.io';
 dotenv.config();
 
 const app = express();
+const allowedOrigins = [
+  'http://localhost:5173',
+  'https://intervyo-sage.vercel.app'
+];
 
 const server = http.createServer(app);
 const io = new Server(server, {
   cors: {
-    origin: process.env.FRONTEND_URL || 'https://intervyo-sage.vercel.app',
+    origin: allowedOrigins,
     methods: ['GET', 'POST'],
     credentials: true
   }
@@ -41,9 +45,16 @@ app.use(helmet());
 // MIDDLEWARE
 // ========================================
 app.use(cors({
-  origin: process.env.CLIENT_URL || 'https://intervyo-sage.vercel.app',
+  origin: function (origin, callback) {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
   credentials: true,
 }));
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(apiLimiter);


### PR DESCRIPTION
### ECWoC 2026 Contribution


Fixed Issue #32 

This PR fixes a CORS misconfiguration that blocked OTP requests when accessing the app from the deployed Vercel frontend.

The backend previously allowed only localhost-based origins.
<img width="1918" height="982" alt="image" src="https://github.com/user-attachments/assets/746d0dda-06e0-454b-bd9e-3f5a7ef20a1f" />

A proper allowlist has now been added for both Express and Socket.IO, supporting local development and production.


This resolves the signup OTP failure.

## NOTE: You have to redeploy the backend for this change to be in effect
