### PR TITLE
Made footer year dynamic instead of hardcoded

### DIFF
--- a/Frontend/src/pages/Landing.jsx
+++ b/Frontend/src/pages/Landing.jsx
@@ -522,7 +522,7 @@ export default function LandingPage() {
           </div>
           
           <div className="border-t border-white/10 pt-8 text-center text-gray-400">
-            <p>&copy; 2024 InterviewPro. All rights reserved.</p>
+            <p>&copy; {new Date().getFullYear()} InterviewPro. All rights reserved.</p>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
## Fix: Dynamic Footer Year

Replaced the hardcoded footer year with a dynamic value using `new Date().getFullYear()` so it stays up to date automatically.  
No functional or dependency changes.

Fixes #47 