### PR TITLE
[Feature] Add dark/light mode toggle to footer

### DIFF
--- a/Frontend/src/components/shared/Footer.jsx
+++ b/Frontend/src/components/shared/Footer.jsx
@@ -2,6 +2,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { TelegramIcon } from "@hugeicons/core-free-icons";
 import { Twitter, Linkedin, Github, Youtube, Mail } from "lucide-react";
 import { Link } from "react-router-dom";
+import ThemeToggle from "../ThemeToggle";
 
 export default function Footer() {
   return (
@@ -180,9 +181,12 @@ export default function Footer() {
         {/* Bottom section */}
         <div className="border-t border-white/5 pt-6">
           <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-            <p className="text-sm text-gray-500">
-              © 2026 Intervyo. All rights reserved.
-            </p>
+            <div className="flex items-center gap-4">
+              <p className="text-sm text-gray-500">
+                © 2026 Intervyo. All rights reserved.
+              </p>
+              <ThemeToggle className="!p-1.5 !bg-zinc-900 !border-white/10" />
+            </div>
             <p className="text-sm text-gray-500">
               Built with <span className="text-red-500">♥</span> for aspiring developers
             </p>


### PR DESCRIPTION
## Summary
This PR adds the dark/light mode toggle to the footer, making it accessible from all pages as requested in issue #229.

## Changes Made

### Footer Component (`src/components/shared/Footer.jsx`)
- Added ThemeToggle component import
- Positioned theme toggle button in the footer's bottom section
- Styled to match the footer's dark theme design
- Available on all pages that display the footer

## Background
The application already had:
- ThemeContext for state management
- ThemeToggle component for the UI
- Theme toggle on Dashboard and some other pages

This change makes the theme toggle globally accessible through the footer, which is shown on all public pages (Landing, About, FAQ, etc.) and most protected pages.

## UI Changes
**Before:** Theme toggle only available on specific pages (Dashboard, Landing, etc.)

**After:** Theme toggle visible in footer on all pages

## Technical Details
- Added import: `import ThemeToggle from "../ThemeToggle";`
- Positioned next to copyright text for easy access
- Custom classes applied: `!p-1.5 !bg-zinc-900 !border-white/10` for consistent styling
- Uses existing ThemeContext and ThemeToggle implementations

## Testing
- Verified toggle works on all pages with footer
- Confirmed theme state persists across page navigation
- Checked that footer properly hides on auth pages (login, register)

Closes #229