### PR TITLE
Protect Interview Room route from unauthorized direct access

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -204,7 +204,11 @@ function App() {
 
         <Route
           path="/interview-room/:interviewId"
-          element={<InterviewRoom />}
+          element={
+            <ProtectedRoute>
+              <InterviewRoom />
+            </ProtectedRoute>
+          }
         />
 
         <Route

--- a/Frontend/src/components/AiInterview/InterviewRoom.jsx
+++ b/Frontend/src/components/AiInterview/InterviewRoom.jsx
@@ -9,6 +9,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
 import io from "socket.io-client";
 import Editor from "@monaco-editor/react";
+import { toast } from "react-hot-toast";
 import {
   Code2,
   X,
@@ -169,6 +170,10 @@ const InterviewRoom = () => {
         ) {
           updateMetricsFromEvaluations(sessionData.questionEvaluations);
         }
+      } else if (interviewData.status === "completed") {
+        toast.error("This interview session has already been completed.");
+        navigate(`/results/${interviewId}`);
+        return;
       } else {
         setCurrentMessage(
           "Ready to start? Click the button below when you're prepared.",
@@ -178,8 +183,8 @@ const InterviewRoom = () => {
       setLoading(false);
     } catch (error) {
       console.error("❌ Init error:", error);
-      addNotification("Failed to load interview. Redirecting...", "error");
-      setTimeout(() => navigate("/dashboard"), 2000);
+      toast.error("Please start or join an interview session first.");
+      navigate("/dashboard");
     }
   };
 
@@ -221,6 +226,8 @@ const InterviewRoom = () => {
   // ============================================
 
   useEffect(() => {
+    if (!interview) return;
+
     let mounted = true;
     let localStream = null;
 


### PR DESCRIPTION
## Description
Added route protection to prevent direct navigation to the Interview Room without an active interview session.

## Related Issue
Closes #406 

## Changes Made
- Added validation before rendering InterviewRoom.
- Redirected unauthorized users.
- Preserved existing interview flows.
- Prevented runtime errors caused by missing session data.

## Checklist
- [x] Tested locally
- [x] No regressions
- [x] Linked the related issue