### PR TITLE
docs: fix case mismatch in clone directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Simple, scalable, and not over-engineered.
 ### 📥 Clone the Repository
 ```bash
 git clone https://github.com/santanu-atta03/Intervyo  
-cd intervyo
+cd Intervyo
 ```
 ---
 


### PR DESCRIPTION
# Pull Request — Intervyo

## 📌 Related Issue
Fixes #None (just a documentation quick fix )

---
## Description of Changes
Fixed a case-sensitivity bug in the setup instructions in README.md — `git clone` creates a folder named `Intervyo` (capital I), but the next command told users to run `cd intervyo` (lowercase), which fails on case-sensitive filesystems like Linux/macOS.

---
## Type of Change
- [x] 🧹 Maintenance / Cleanup / Documentation Update

---
## Testing
- [x] Tested locally
- [ ] No tests required

---
## 📸 Screenshots / Video
N/A — documentation-only fix.

---
## ✅ Checklist
- [x] I've read the **CONTRIBUTING.md** guidelines.
- [x] My code follows the project's conventions.
- [x] I've linked the related issue correctly.
- [x] I've tested my changes locally.
- [ ] I've added or updated documentation/comments if needed.
- [x] My PR title follows the branch & commit naming conventions.
- [x] My changes introduce no new warnings or errors.
- [x] I've performed a self-review of my work.

---
## 💬 Additional Notes (Optional)
Simple one-line case-fix, no functional changes.